### PR TITLE
Move Postgres data to subdirectory, Fixes initdb failing because of non-empty dir

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
+      PGDATA: /var/lib/postgresql/data/pgdata
   cron:
     build: 
       context: './cron/'


### PR DESCRIPTION
Move Postgres data to subdirectory, Fixes initdb failing because of non-empty dir